### PR TITLE
Add .NET 5.0 Target

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="Optimizely" value="https://nuget.optimizely.com/feed/packages.svc" />
+  </packageSources>
+</configuration>

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\dependencies.props" />
   <PropertyGroup>
-	<TargetFramework>net6.0</TargetFramework>
+	<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
 	<Version>2.0.0</Version>
 	<Author>vnbaaij</Author>
 	<Company>Baaijte</Company>
@@ -24,13 +24,10 @@
 	  <PackagePath>\</PackagePath>
 	</None>
   </ItemGroup>
-
-  <ItemGroup>
-	<PackageReference Include="EPiServer.CMS.Core" Version="12.4.2" />
-	<PackageReference Include="EpiServer.Framework" Version="12.4.2" />
-	<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.4.2" />
-	<PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
-	<PackageReference Include="SixLabors.ImageSharp.Web" Version="2.0.0" />
-  </ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2,13.0.0)" />
+		<PackageReference Include="SixLabors.ImageSharp.Web" Version="[2.0.0,3.0.0)" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi, 

This is a suggestive PR that adds back .NET 5.0 as a target and also keeps .NET 6.0. 

It also simplify dependencies, leaving this package to be only dependent to the dependencies explicitly defined within the csproj file. 

Thank you,
David