### PR TITLE
Use last modified date from MediaData to ensure correct value

### DIFF
--- a/src/Baaijte.Optimizely.ImageSharp.Web/Providers/BlobImageProvider.cs
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Providers/BlobImageProvider.cs
@@ -58,7 +58,7 @@ namespace Baaijte.Optimizely.ImageSharp.Web.Providers
 
             if (media != null && media.BinaryData != null)
             {
-                return Task.FromResult<IImageResolver>(new BlobImageResolver(media.BinaryData));
+                return Task.FromResult<IImageResolver>(new BlobImageResolver(media));
             }
             return Task.FromResult<IImageResolver>(null);
         }

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Resolvers/BlobImageResolver.cs
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Resolvers/BlobImageResolver.cs
@@ -1,8 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
-
-using EPiServer.Framework.Blobs;
-
+using EPiServer.Core;
 using Microsoft.Extensions.FileProviders;
 
 using SixLabors.ImageSharp.Web;
@@ -12,28 +11,29 @@ namespace Baaijte.Optimizely.ImageSharp.Web.Resolvers
 {
     public class BlobImageResolver : IImageResolver
     {
-        private readonly Blob blob;
+        private readonly MediaData media;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobImageResolver"/> class.
         /// </summary>
-        /// <param name="blob">The image blob.</param>
+        /// <param name="media">The image.</param>
 
-        public BlobImageResolver(Blob blob)
+        public BlobImageResolver(MediaData media)
         {
-            this.blob = blob;
+            this.media = media;
         }
 
         /// <inheritdoc/>
         public async Task<ImageMetadata> GetMetaDataAsync()
         {
-            IFileInfo fileInfo = await blob.AsFileInfoAsync();
+            DateTimeOffset lastModified = media.Saved;
+            IFileInfo fileInfo = await media.BinaryData.AsFileInfoAsync(lastModified);
 
-            return new(fileInfo.LastModified.UtcDateTime, fileInfo.Length);
+            return new(lastModified.UtcDateTime, fileInfo.Length);
         }
 
         /// <inheritdoc/>
-        public Task<Stream> OpenReadAsync() => Task.FromResult(blob.OpenRead());
+        public Task<Stream> OpenReadAsync() => Task.FromResult(media.BinaryData.OpenRead());
 
     }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Uses `Saved` date from MediaData content to ensure proper last modified date metadata when storing cached resized images. Currently it, at least sometimes, uses the fallback value `DateTime.Today` instead.

### 🎫 Issues

#16 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

With DXP configuration, browse to a resized image. Ensure "SM" metadata on resized image in Azure blob container corresponds to modified date of image in Optimizely CMS.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

Starting with providing this suggested change. Will come to testing as soon as I can make time.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
