### PR TITLE
Update ImageSharp dependencies (main, Web and Web.Providers.Azure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ## What's New
+
+### V2.2.1
+Package now uses SixLabors.ImageSharp 3.0.2 and SixLabors.ImageSharp.Web 3.0.1.
+Package now also references SixLabors.ImageSharp.Web.Providers.Azure
+
 ### V2.2.0
 Package now uses SixLabors.ImageSharp 3.0.1 and SixLabors.ImageSharp.Web 3.0.1
 
@@ -12,7 +17,7 @@ Package now uses SixLabors.ImageSharp 3.0.1 and SixLabors.ImageSharp.Web 3.0.1
 
 ### Installation
   
-Baaijte.OptimizelyImageSharp.Web is installed via the [Optimizely NuGet feed](https://nuget.episerver.com/package/?id=Baaijte.Optimizely.ImageSharp.Web) 
+Baaijte.OptimizelyImageSharp.Web is installed via the [Optimizely NuGet feed](https://nuget.optimizely.com/package/?id=Baaijte.Optimizely.ImageSharp.Web) 
 
 #### [Package Manager](#tab/tabid-1)
 

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
@@ -2,7 +2,7 @@
 	<Import Project="..\..\dependencies.props" />
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>2.2.0</Version>
+		<Version>2.2.1</Version>
 		<Author>vnbaaij</Author>
 		<Company>Baaijte</Company>
 		<Description>Use SixLabors.ImageSharp.Web in Optimizely</Description>
@@ -34,10 +34,11 @@
 	<ItemGroup>
 		<PackageReference Include="EPiServer.Framework" Version="12.17.0" />
 		<PackageReference Include="EPiServer.CMS.Core" Version="12.17.0" />
-		<PackageReference Include="EPiServer.CMS" Version="12.22.3" />				
-		<PackageReference Include="EPiServer.ImageLibrary.ImageSharp" Version="2.0.0" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+		<PackageReference Include="EPiServer.CMS" Version="12.22.3" />
+		<PackageReference Include="EPiServer.ImageLibrary.ImageSharp" Version="2.0.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
 		<PackageReference Include="SixLabors.ImageSharp.Web" Version="3.0.1" />
+		<PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
@@ -15,7 +15,7 @@
     <tags>Optimizely ImageSharp Blob Cache</tags>
     <dependencies>
       <group targetFramework="net6.0">
-      <dependency id="SixLabors.ImageSharp" version="3.0.1" />
+      <dependency id="SixLabors.ImageSharp" version="3.0.2" />
       <dependency id="SixLabors.ImageSharp.Web" version="3.0.1" />
       <dependency id="EPiServer.CMS" version="[12.13.0, 13.0.0)" />
       </group>

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
@@ -17,6 +17,7 @@
       <group targetFramework="net6.0">
       <dependency id="SixLabors.ImageSharp" version="3.0.2" />
       <dependency id="SixLabors.ImageSharp.Web" version="3.0.1" />
+      <dependency id="SixLabors.ImageSharp.Web.Providers.Azure" version="3.0.1" />
       <dependency id="EPiServer.CMS" version="[12.13.0, 13.0.0)" />
       </group>
     </dependencies>


### PR DESCRIPTION
# Update ImageSharp related dependencies to latest versions

## 📖 Description

Update ImageSharp referenced libraries:
* EPiServer.ImageLibrary.ImageSharp `2.0.0` - `2.0.1`
* SixLabors.ImageSharp `3.0.1` - `3.0.2` 
* *new* SixLabors.ImageSharp.Web.Providers.Azure `3.0.2` 

I've referenced `SixLabors.ImageSharp.Web.Providers.Azure`, because when configuring for DXP one needs to reference this library either way, so it's one less thing to think about when using `Baaijte.Optimizely.ImageSharp.Web` 🙂 

## 👩‍💻 Reviewer Notes

I've updated the library version to `2.2.1` - please verify if I haven't missed any place, where this needs to be set.

## 📑 Test Plan

Just a smoke test is sufficient - [latest version of ImageSharp](https://github.com/SixLabors/ImageSharp/releases/tag/v3.0.2) only patches a security vulnerability.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

If this PR would be approved, I would appreciate updating the Nuget package on Optimizely feed.
