### PR TITLE
Remove redundant and conflicting Epi deps

### DIFF
--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
@@ -32,8 +32,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="EPiServer.Framework" Version="12.20.0" />
-		<PackageReference Include="EPiServer.CMS.Core" Version="12.20.0" />
 		<PackageReference Include="EPiServer.CMS" Version="12.25.1" />
 		<PackageReference Include="EPiServer.ImageLibrary.ImageSharp" Version="2.0.1" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />


### PR DESCRIPTION
# Pull Request

## 📖 Description

When only importing the Epi umbrella package (EPiServer.CMS) and not specific ones (like EPiServer.CMS.Core) in a consuming project you could be hit with the following error:

<img width="1380" alt="image" src="https://github.com/vnbaaij/Baaijte.Optimizely.ImageSharp.Web/assets/8577089/0bfcecf7-5501-4058-9e36-360821fa78b3">

The reason is EPiServer.CMS has a dependency of those packages defined as ≥ 12.19.0 and dotnet restore will default to install the lowest possible version (https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution#lowest-applicable-version). 

This PR should fix this.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.