### PR TITLE
Upgrade to net8, upgrade of SixLabors and Wanakanai packages

### DIFF
--- a/sample/AlloyMVC/AlloyMVC.csproj
+++ b/sample/AlloyMVC/AlloyMVC.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>disable</Nullable>
 	</PropertyGroup>
 
@@ -10,18 +10,18 @@
 		<PackageReference Include="EPiServer.Framework.AspNetCore" Version="12.20.0" />
 		<PackageReference Include="EPiServer.Hosting" Version="12.20.0" />
 		<PackageReference Include="EPiServer.CMS.AspNetCore.TagHelpers" Version="12.20.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.10" />
-		<PackageReference Include="Wangkanai.Detection" Version="2.0.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+		<PackageReference Include="Wangkanai.Detection" Version="8.12.0" />
 		<!-- Extra top level dependencies needed to force CMS 6 compatible version of CMS Core -->
 		<PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="12.20.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
 		<!-- Extra top level dependencies needed until our CloudPlatform and AspnetIdentity packages are updated to declare .NET 6 dependencies -->
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.10" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.28" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/sample/AlloyMVC/Business/Channels/MobileChannel.cs
+++ b/sample/AlloyMVC/Business/Channels/MobileChannel.cs
@@ -1,7 +1,8 @@
 using EPiServer.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Wangkanai.Detection;
+using Wangkanai.Detection.Models;
+using Wangkanai.Detection.Services;
 
 namespace AlloyMVC.Business.Channels
 {
@@ -18,8 +19,8 @@ namespace AlloyMVC.Business.Channels
 
         public override bool IsActive(HttpContext context)
         {
-            var detection = context.RequestServices.GetRequiredService<IDetection>();
-            return detection.Device.Type == DeviceType.Mobile;
+            var detection = context.RequestServices.GetRequiredService<IDetectionService>();
+            return detection.Device.Type == Device.Mobile;
         }
     }
 }

--- a/sample/AlloyMVC/Business/Channels/WebChannel.cs
+++ b/sample/AlloyMVC/Business/Channels/WebChannel.cs
@@ -1,7 +1,8 @@
 using EPiServer.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Wangkanai.Detection;
+using Wangkanai.Detection.Models;
+using Wangkanai.Detection.Services;
 
 namespace AlloyMVC.Business.Channels
 {
@@ -14,8 +15,8 @@ namespace AlloyMVC.Business.Channels
 
         public override bool IsActive(HttpContext context)
         {
-            var detection = context.RequestServices.GetRequiredService<IDetection>();
-            return detection.Device.Type == DeviceType.Desktop;
+            var detection = context.RequestServices.GetRequiredService<IDetectionService>();
+            return detection.Device.Type == Device.Desktop;
         }
     }
 }

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="..\..\dependencies.props" />
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<Version>2.2.1</Version>
+		<TargetFramework>net8.0</TargetFramework>
+		<Version>2.2.2</Version>
 		<Author>vnbaaij</Author>
 		<Company>Baaijte</Company>
 		<Description>Use SixLabors.ImageSharp.Web in Optimizely</Description>
@@ -34,9 +34,9 @@
 	<ItemGroup>
 		<PackageReference Include="EPiServer.CMS" Version="12.25.1" />
 		<PackageReference Include="EPiServer.ImageLibrary.ImageSharp" Version="2.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
-		<PackageReference Include="SixLabors.ImageSharp.Web" Version="3.0.1" />
-		<PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.0.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
+		<PackageReference Include="SixLabors.ImageSharp.Web" Version="3.1.1" />
+		<PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Baaijte.Optimizely.ImageSharp.Web.nuspec
@@ -15,9 +15,9 @@
     <tags>Optimizely ImageSharp Blob Cache</tags>
     <dependencies>
       <group targetFramework="net6.0">
-      <dependency id="SixLabors.ImageSharp" version="3.0.2" />
-      <dependency id="SixLabors.ImageSharp.Web" version="3.0.1" />
-      <dependency id="SixLabors.ImageSharp.Web.Providers.Azure" version="3.0.1" />
+      <dependency id="SixLabors.ImageSharp" version="3.1.3" />
+      <dependency id="SixLabors.ImageSharp.Web" version="3.1.1" />
+      <dependency id="SixLabors.ImageSharp.Web.Providers.Azure" version="3.1.1" />
       <dependency id="EPiServer.CMS" version="[12.13.0, 13.0.0)" />
       </group>
     </dependencies>


### PR DESCRIPTION
Upgrade to net8, upgrade of SixLabors and Wanakanai packages

Optimizely now supports net8 and there for I upgrade to net8 and the latest packages of SixLabors and Wanakanai

Upgrade of the following packages in Baaijte.Optimizely.ImageSharp.Web:
        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
        <PackageReference Include="SixLabors.ImageSharp.Web" Version="3.1.1" />
        <PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.1" />

Upgrade of the following packages in Alloy:
        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.28" />
        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
        <PackageReference Include="Wangkanai.Detection" Version="8.12.0" />
