### PR TITLE
Fixed: When cache folder differs from the site blobs folder, cached files are never found.

### DIFF
--- a/sample/Alloy/Startup.cs
+++ b/sample/Alloy/Startup.cs
@@ -1,5 +1,6 @@
 using AlloyMVC.Extensions;
 using Baaijte.Optimizely.ImageSharp.Web;
+using Baaijte.Optimizely.ImageSharp.Web.Caching;
 using EPiServer.Cms.UI.AspNetIdentity;
 using EPiServer.Data;
 using EPiServer.DependencyInjection;
@@ -33,6 +34,14 @@ public class Startup(IWebHostEnvironment webHostingEnvironment)
 
         services.AddBaaijteOptimizelyImageSharp();
 
+        // Configure a different location for the cache.
+        services.Configure<BlobImageCacheOptions>(o =>
+        {
+            var dir = Directory.CreateDirectory(
+                Path.Combine(webHostingEnvironment.ContentRootPath, "App_Data", "img-cache"));
+            o.CacheFolder = dir.FullName;
+        });
+
         services.AddSession(options =>
         {
             options.IdleTimeout = TimeSpan.FromSeconds(10);
@@ -51,7 +60,7 @@ public class Startup(IWebHostEnvironment webHostingEnvironment)
         // Required by Wangkanai.Detection
         app.UseDetection();
         app.UseSession();
-        
+
         app.UseBaaijteOptimizelyImageSharp();
 
         app.UseStaticFiles();

--- a/src/Baaijte.Optimizely.ImageSharp.Web/Caching/BlobImageCache.cs
+++ b/src/Baaijte.Optimizely.ImageSharp.Web/Caching/BlobImageCache.cs
@@ -1,11 +1,9 @@
 ﻿using EPiServer;
 using EPiServer.Core;
 using EPiServer.Framework.Blobs;
-using EPiServer.ServiceLocation;
 using EPiServer.Web.Routing;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web;
 using SixLabors.ImageSharp.Web.Caching;
@@ -73,25 +71,15 @@ namespace Baaijte.Optimizely.ImageSharp.Web.Caching
         /// <inheritdoc/>
         public async Task<IImageCacheResolver> GetAsync(string key)
         {
-            string container = GetContainer();
-            string fileId = $"{Blob.BlobUriScheme}://{Blob.DefaultProvider}/{container}/{cacheOptions.Prefix}{key}";
-
-            IBlobFactory blobFactory = ServiceLocator.Current.GetInstance<IBlobFactory>();
-            Uri uri = new($"{fileId}.meta");
-
-            Blob blob = blobFactory.GetBlob(uri);
-
+            var fileName = $"{cacheOptions.Prefix}{key}";
+            var blob = CreateBlob($"{fileName}.meta");
             if (!await blob.ExistsAsync())
             {
                 return null;
             }
 
-            ImageCacheMetadata metadata = await ImageCacheMetadata.ReadAsync(await blob.OpenReadAsync());
-
-            uri = new($"{fileId}{ToImageExtension(metadata)}");
-            blob = blobFactory.GetBlob(uri);
-
-            // Check to see if the file exists.
+            var metadata = await ImageCacheMetadata.ReadAsync(await blob.OpenReadAsync());
+            blob = CreateBlob($"{fileName}{ToImageExtension(metadata)}");
             if (!await blob.ExistsAsync())
             {
                 return null;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This is a fix.

When the cache folder differs from the site blobs folder, cached files are never found. Cache files along with metadata files are created correctly at the configured cache folder. This ends up in a situation where cached files are recreated on each and every attempt at getting content from the cache.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan
The only way to confirm the bug will have to be to:

1. Clone the current version of this repository
2. Configure a cache folder different from the blobs folder. Similar to what is found in this PR
3. Add logging within the GetAsync() method in Caching/BlobImageCache.cs
4. Observe that cached files are never found, but always created

When testing the changes in this PR:
1. Apply this PR to a test branch and clone that
2. Add logging to the new GetAsync() code
3. Observe that cached files are now found and served
4. Comment out the code that configures cache folder in Alloys Startup.cs
5. Observe that caced files are found and served

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast-blazor/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
